### PR TITLE
Improve template library UI

### DIFF
--- a/src/app/template-library/template-card/template-card.component.scss
+++ b/src/app/template-library/template-card/template-card.component.scss
@@ -1,5 +1,6 @@
 .template-card {
   margin: 3px;
+  height: 100%;
 }
 
 .card-media {

--- a/src/app/template-library/template-details/template-details.component.spec.ts
+++ b/src/app/template-library/template-details/template-details.component.spec.ts
@@ -78,11 +78,6 @@ describe('TemplateDetailsComponent', () => {
     expect(fixture.debugElement.query(By.css('.template-title')).nativeElement.innerText).toEqual(template.name);
   });
 
-  it('should call import experience', () => {
-    component.importTemplate('abc123');
-    expect(templateLibraryServiceSpy.importExperience).toHaveBeenCalledWith('abc123');
-  });
-
   afterEach(() => {
     fixture.destroy();
   });

--- a/src/app/template-library/template-details/template-details.component.ts
+++ b/src/app/template-library/template-details/template-details.component.ts
@@ -1,6 +1,8 @@
 import { Component, OnInit } from '@angular/core';
 import {ActivatedRoute} from '@angular/router';
 import {Template, TemplateLibraryService} from '../template-library.service';
+import { environment } from '@environments/environment';
+import { urlFormatter } from '../../../helper';
 
 @Component({
   selector: 'app-template-details',
@@ -36,6 +38,7 @@ export class TemplateDetailsComponent implements OnInit {
       this.importingTemplate = false;
       console.log('Navigate the user somewhere?');
       console.log(res);
+      window.top.location.href = urlFormatter(environment.Practera, `/users/change/experience/${res.experienceUuid}?redirect=/design`);
     });
   }
 

--- a/src/app/template-library/template-details/template-details.component.ts
+++ b/src/app/template-library/template-details/template-details.component.ts
@@ -36,8 +36,6 @@ export class TemplateDetailsComponent implements OnInit {
     this.importingTemplate = true;
     this.service.importExperience(templateId).subscribe(res => {
       this.importingTemplate = false;
-      console.log('Navigate the user somewhere?');
-      console.log(res);
       window.top.location.href = urlFormatter(environment.Practera, `/users/change/experience/${res.experienceUuid}?redirect=/design`);
     });
   }

--- a/src/app/template-library/template-library.component.html
+++ b/src/app/template-library/template-library.component.html
@@ -2,7 +2,8 @@
   <ion-split-pane class="template-library-container" contentId="main">
     <ion-menu contentId="main" class="menu border-0">
       <ion-header>
-        <ion-toolbar>
+        <ion-toolbar class="template-library-toolbar">
+          <ion-button href="/overview-only" color="medium" slot="start"><ion-icon name="home"></ion-icon></ion-button>
           <ion-searchbar class="template-search-bar" color="light" (ionChange)="onSearch($event)"></ion-searchbar>
         </ion-toolbar>
       </ion-header>

--- a/src/app/template-library/template-library.component.scss
+++ b/src/app/template-library/template-library.component.scss
@@ -1,6 +1,11 @@
+.template-library-container {
+  padding-top: 20px;
+}
+
 @media (min-width:992px) {
   .template-library-container {
     //width: 85%;
+    padding-top: 20px;
     max-width: 1200px;
     margin: auto;
   }
@@ -13,7 +18,7 @@
 }
 
 .template-search-bar {
-  padding: 4px 5px 0px 2px;
+  padding: 0px 5px 0px 2px;
   --box-shadow: none;
 }
 
@@ -25,4 +30,8 @@
 
 ion-item.active {
   font-weight: bold;
+}
+
+.template-library-toolbar {
+  padding-left: 16px
 }


### PR DESCRIPTION
* Add padding at the top of the template library because was too close to top nave
* Make cards 100% height so all cards in the same line are same height
* Redirect after template import
* Added a home button to go back to "overview-only"