### PR TITLE
Remove the specific src tag for the template video and just use the g…

### DIFF
--- a/src/app/template-library/template-details/template-details.component.html
+++ b/src/app/template-library/template-details/template-details.component.html
@@ -34,9 +34,7 @@
           <ion-col size="8">
             <ng-container *ngIf="template.leadVideoUrl">
               <div>
-                <video class="lead-video" preload="auto" controls>
-                  <source [src]=[template.leadVideoUrl] type="video/webm" />
-                </video>
+                <video class="lead-video" preload="auto" controls [src]=[template.leadVideoUrl]></video>
               </div>
             </ng-container>
             <div>


### PR DESCRIPTION
…eneric src the attribute of the video

I figure as we are only providing a single url for the video we may as well only use the attribute of the video tag