### PR TITLE
[CUT-152] When "Change Schedule" selected, the popup does not display the originally set date and time

### DIFF
--- a/src/app/chat/chat-room/chat-room.component.ts
+++ b/src/app/chat/chat-room/chat-room.component.ts
@@ -773,7 +773,8 @@ export class ChatRoomComponent {
       componentProps: {
         chatMessage: this.messageList[index],
         channelName: this.chatChannel.name,
-        reScheduled: false
+        reScheduled: false,
+        isSentMessageEdit: true
       }
     });
     await modal.present();

--- a/src/app/chat/edit-schedule-message-popup/edit-schedule-message-popup.component.html
+++ b/src/app/chat/edit-schedule-message-popup/edit-schedule-message-popup.component.html
@@ -31,7 +31,7 @@
       <div class="message-container" *ngIf="!reScheduled">
         <p class="subtitle-2 black">{{ message }}</p>
       </div>
-      <div class="schedule-info-container">
+      <div class="schedule-info-container" *ngIf="!isSentMessageEdit">
         <p class="subtitle-2 black">Scheduled for <strong>{{ utils.utcLocalforScheduleMessages(scheduledDateTime, 'date') }}</strong> at <strong>{{ utils.utcLocalforScheduleMessages(scheduledDateTime, 'time') }} ({{ utils.browserTimezone() }})</strong> on <strong>{{ channelName }}</strong></p>
       </div>
     </div>

--- a/src/app/chat/edit-schedule-message-popup/edit-schedule-message-popup.component.html
+++ b/src/app/chat/edit-schedule-message-popup/edit-schedule-message-popup.component.html
@@ -2,7 +2,9 @@
   <ng-container *ngIf="!updateSuccess; else messageCreated">
     <p class="subtitle-2 popup-title">{{ reScheduled ? 'Modify Shedule' : 'Edit Message' }}</p>
 
-    <p class="caption hint-message" *ngIf="reScheduled">select date and time at least 30 minutes in the future</p>
+    <p class="caption hint-message" *ngIf="reScheduled"><strong>{{ utils.browserTimezone() }} Timezone</strong></p>
+
+    <p class="caption hint-message" *ngIf="reScheduled">select the date and time at least 30 minutes in the future</p>
 
     <div class="form-container" [ngClass]="{'edit': !reScheduled}">
       <ng-container *ngIf="reScheduled; else editMessage">
@@ -30,14 +32,14 @@
         <p class="subtitle-2 black">{{ message }}</p>
       </div>
       <div class="schedule-info-container">
-        <p class="subtitle-2 black">will be publised the <strong>{{ utils.utcToLocal(scheduledDateTime, 'date') }}</strong> at <strong>{{ utils.utcToLocal(scheduledDateTime, 'time') }}</strong> on <strong>{{ channelName }}</strong></p>
+        <p class="subtitle-2 black">Scheduled for <strong>{{ utils.utcLocalforScheduleMessages(scheduledDateTime, 'date') }}</strong> at <strong>{{ utils.utcLocalforScheduleMessages(scheduledDateTime, 'time') }} ({{ utils.browserTimezone() }})</strong> on <strong>{{ channelName }}</strong></p>
       </div>
     </div>
   </ng-template>
 </div>
 <div class="message-popup-footer">
   <ion-button color="light" class="btn-cancle" (click)="close()" [disabled]="sending">
-    Cancel
+    {{ updateSuccess ? 'Close' : 'Cancel' }}
   </ion-button>
   <ion-button *ngIf="!updateSuccess" color="ocean" (click)="EditMessage()"
     [disabled]="sending || !messageUuid">

--- a/src/app/chat/edit-schedule-message-popup/edit-schedule-message-popup.component.ts
+++ b/src/app/chat/edit-schedule-message-popup/edit-schedule-message-popup.component.ts
@@ -50,6 +50,11 @@ export class EditScheduleMessagePopupComponent implements OnInit {
     this.message = this.chatMessage ? this.chatMessage.message : null;
     this.messageUuid = this.chatMessage ? this.chatMessage.uuid : null;
     this.scheduledDateTime = this.chatMessage ? this.chatMessage.scheduled : null;
+    if (this.reScheduled) {
+      const originalDateTime = this.utils.iso8601Formatter(this.scheduledDateTime);
+      this.selectedDate = moment(new Date(originalDateTime)).format('YYYY-MM-DD');
+      this.selectedTime = moment(new Date(originalDateTime)).format('HH:mm:ss');
+    }
   }
 
   /**

--- a/src/app/chat/edit-schedule-message-popup/edit-schedule-message-popup.component.ts
+++ b/src/app/chat/edit-schedule-message-popup/edit-schedule-message-popup.component.ts
@@ -19,6 +19,7 @@ export class EditScheduleMessagePopupComponent implements OnInit {
   @Input() reScheduled = false;
   @Input() chatMessage: Message;
   @Input() channelName: string;
+  @Input() isSentMessageEdit = false;
   messageUuid: string;
   selectedDate: string;
   selectedTime: string;

--- a/src/app/chat/schedule-message-popup/schedule-message-popup.component.html
+++ b/src/app/chat/schedule-message-popup/schedule-message-popup.component.html
@@ -4,7 +4,7 @@
 
     <p class="caption hint-message"><strong>{{ utils.browserTimezone() }} Timezone</strong></p>
 
-    <p class="caption hint-message">select date and time at least 30 minutes in the future</p>
+    <p class="caption hint-message">select the date and time at least 30 minutes in the future</p>
 
     <div class="form-container">
 


### PR DESCRIPTION
**Story/Ticket Reference ID from JIRA:**
https://intersective.atlassian.net/browse/CUT-152

**Additional Comments:**
added timezone to edit popup.
update success message.
add logic to set original date time when popup open.
update hit message.

**Checklist:**

- [x] Unit test completed?: (Y/N)
- [x] Docs folder up to date?: (Y/N)
- [x] Add if anything missed: (Y/N)

All checklist are okay.

This PR looks great - it's ready to merge! Please review and let's ship it. :)