### PR TITLE
[CORE-6513] metrics card and detail popup update - trunk

### DIFF
--- a/src/app/metrics/metric-card/metric-card.component.html
+++ b/src/app/metrics/metric-card/metric-card.component.html
@@ -1,4 +1,5 @@
-<ion-card class="metrics-card" (click)="openModal()" [button]="true">
+<ion-card class="metrics-card" (click)="from === 'library' ? '' : openModal()"
+  [button]="from === 'library' ? false : true">
   <ng-container [ngSwitch]="from">
     <ion-card-content *ngSwitchCase="'experience'">
       <ng-container *ngTemplateOutlet="experienceCardContent"></ng-container>
@@ -24,6 +25,34 @@
   </div>
   <div class="description space">
     <p class="black">{{ data.description }}</p>
+  </div>
+  <div class="description space">
+    <p class="black"><span>Aggregation: </span>{{ data.aggregation }}</p>
+  </div>
+  <ion-grid class="ion-no-padding">
+    <ion-row class="ion-justify-content-between ion-align-items-center ion-no-padding">
+      <ion-col class="ion-no-padding">
+        <p class="black"><span>Filter Role: </span>{{ data.filterRole.join(', ') | titlecase }}</p>
+      </ion-col>
+      <ion-col class="ion-no-padding">
+        <p class="black"><span>Filter Status: </span>{{ data.filterStatus.join(', ') | titlecase }}</p>
+      </ion-col>
+    </ion-row>
+  </ion-grid>
+  <div class="useBtn-container">
+    <ng-container *ngIf="data.status; else elseBlock">
+      <div class="matric-status-chip active">
+        <p>Used</p>
+      </div>
+    </ng-container>
+    <ng-template #elseBlock>
+      <ion-select label="Use Metric" interface="popover" fill="outline" mode="md" color="ocean"
+        (ionChange)="useMetric($event.detail.value)">
+        <ion-select-option value="required">Required</ion-select-option>
+        <ion-select-option value="recommended">Recommended</ion-select-option>
+        <ion-select-option value="not_required">Not Required</ion-select-option>
+      </ion-select>
+    </ng-template>
   </div>
 </ng-template>
 

--- a/src/app/metrics/metric-card/metric-card.component.scss
+++ b/src/app/metrics/metric-card/metric-card.component.scss
@@ -1,4 +1,5 @@
 .metrics-card {
+  box-shadow: rgba(0, 0, 0, 0.25) 0px 0px 15px 0px;
   .title-status-container {
     display: flex;
     align-items: center;
@@ -24,9 +25,22 @@
       }
     }
   }
+  p {
+    span {
+      font-weight: var(--font-weight-bold) !important;
+    }
+  }
   .description {
     &.space {
       margin: 8px 0px;
     }
-  } 
+  }
+  .useBtn-container {
+    display: flex;
+    justify-content: end;
+    margin-top: 12px;
+    ion-select {
+      width: 50% !important;
+    }
+  }
 }

--- a/src/app/metrics/metric-card/metric-card.component.ts
+++ b/src/app/metrics/metric-card/metric-card.component.ts
@@ -1,8 +1,10 @@
 import { MetricsService } from '@app/metrics/metrics.service';
 import { Component, Input } from '@angular/core';
+import { first } from 'rxjs';
 import type { Metric } from '../metrics.service';
 import { ModalController } from '@ionic/angular';
 import { MetricDetailComponent } from '../metric-detail/metric-detail.component';
+import { Router } from '@angular/router';
 @Component({
   selector: 'app-metric-card',
   templateUrl: './metric-card.component.html',
@@ -16,6 +18,7 @@ export class MetricComponent {
   constructor(
     private modalController: ModalController,
     private metricsService: MetricsService,
+    private router: Router,
   ) { }
 
   async openModal() {
@@ -43,5 +46,14 @@ export class MetricComponent {
     } else {
       return "NOT CONFIGURED";
     }
+  }
+
+  useMetric(requirement) {
+    this.metricsService.useMetric(this.data, requirement).subscribe({
+      complete: () => {
+        this.metricsService.getMetrics(this.from === 'library').pipe(first()).subscribe();
+        this.router.navigate(['metrics', 'institution']);
+      }
+    });
   }
 }

--- a/src/app/metrics/metric-detail/metric-detail.component.html
+++ b/src/app/metrics/metric-detail/metric-detail.component.html
@@ -37,7 +37,7 @@
         </div>
       </ion-col>
     </ion-row>
-    <ng-container *ngIf="metric.lastRecord">
+    <ng-container *ngIf="from === 'experience' && metric.lastRecord">
       <ion-row>
         <ion-col>
           <div class="metric-record-data-container">
@@ -54,18 +54,23 @@
     </ion-row>
     <ion-row>
       <ion-col>
+        <p><span>Aggregation:</span>{{ metric.aggregation | titlecase }}</p>
+      </ion-col>
+    </ion-row>
+    <ion-row>
+      <ion-col>
         <p><span>Filter Role:</span> {{ metric.filterRole.join(', ') | titlecase }}</p>
       </ion-col>
       <ion-col>
         <p><span>Filter Status:</span> {{ metric.filterStatus.join(', ') | titlecase }}</p>
       </ion-col>
     </ion-row>
-    <ion-row>
+    <ion-row *ngIf="from === 'institution'">
       <ion-col>
         <p><span>Public:</span> {{ metric.isPublic ? 'Yes' : 'No' }}</p>
       </ion-col>
     </ion-row>
-    <ng-container *ngIf="metric.assessment">
+    <ng-container *ngIf="from === 'experience' && metric.assessment">
       <ion-row>
         <ion-col>
           <p><span>Assessment Details</span></p>
@@ -100,16 +105,6 @@
           <ion-button size="default" shape="round" color="ocean" *ngIf="metric.status === 'active'" (click)="action('setDraft')">Convert to Draft</ion-button>
           <ion-button size="default" shape="round" color="ocean" *ngIf="metric.status === 'active'" (click)="action('archive')">Archive</ion-button>
           <ion-button size="default" shape="round" color="ocean" *ngIf="metric.status === 'draft' || metric.status === 'archived'" (click)="action('activate')">Set Active</ion-button>
-        </ng-container>
-        <ng-container *ngSwitchCase="'library'">
-          <ion-item lines="none">
-            <ion-select label="Use Metric" interface="action-sheet" cancelText="Cancel"
-              (ionChange)="useMetric($event.detail.value)" [value]="metric.requirement">
-              <ion-select-option value="required">Required</ion-select-option>
-              <ion-select-option value="recommended">Recommended</ion-select-option>
-              <ion-select-option value="not_required">Not Required</ion-select-option>
-            </ion-select>
-          </ion-item>
         </ng-container>
         <ng-container *ngSwitchDefault>
           <ion-button size="default" shape="round" color="ocean" (click)="action('edit')">Edit</ion-button>

--- a/src/app/metrics/metric-detail/metric-detail.component.ts
+++ b/src/app/metrics/metric-detail/metric-detail.component.ts
@@ -73,15 +73,6 @@ export class MetricDetailComponent implements OnInit {
       });
     });
   }
-
-  useMetric(requirement) {
-    this.metricsService.useMetric(this.metric, requirement).subscribe({
-      complete: () => {
-        this.dismissModal();
-        this.metricsService.getMetrics(this.from === 'library').pipe(first()).subscribe();
-      }
-    });
-  }
   
   setDraft() {
   }

--- a/src/app/metrics/metrics-library/metrics-library.component.html
+++ b/src/app/metrics/metrics-library/metrics-library.component.html
@@ -1,6 +1,10 @@
 <ion-content class="metrics-dashboard ion-padding">
-  <div class="title-container ion-justify-content-between">
-    <h1 class="heading-3 black">Library Metrics Dashboard</h1>
+  <div class="title-container">
+    <ion-button fill="clear" (click)="goBack()">
+      <ion-icon slot="start" name="arrow-back-outline"></ion-icon>
+      Metrics Dashboard
+    </ion-button>
+    <h1 class="heading-3 black">Metrics Library</h1>
   </div>
 
   <ion-grid>

--- a/src/app/metrics/metrics-library/metrics-library.component.scss
+++ b/src/app/metrics/metrics-library/metrics-library.component.scss
@@ -1,0 +1,11 @@
+.title-container {
+    margin-bottom: 16px;
+    display: flex;
+    align-items: center;
+    ion-button {
+        margin-right: 12px;
+    }
+    h1 {
+        margin: 0;
+    }
+}

--- a/src/app/metrics/metrics-library/metrics-library.component.ts
+++ b/src/app/metrics/metrics-library/metrics-library.component.ts
@@ -1,16 +1,20 @@
 import { Component, OnInit } from '@angular/core';
 import { MetricsService } from '../metrics.service';
 import { first } from 'rxjs';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-metrics-library',
   templateUrl: './metrics-library.component.html',
-  styleUrls: ['./metrics-library.component.css']
+  styleUrls: ['./metrics-library.component.scss']
 })
 export class MetricsLibraryComponent implements OnInit {
   metrics: any[];
 
-  constructor(private metricsService: MetricsService) { }
+  constructor(
+    private metricsService: MetricsService,
+    private router: Router,
+  ) { }
 
   ngOnInit() {
     this.metricsService.metrics$.subscribe((metrics) => {
@@ -22,5 +26,9 @@ export class MetricsLibraryComponent implements OnInit {
   fetchMetrics() {
     // Library metrics: publicOnly = true
     this.metricsService.getMetrics(true).pipe(first()).subscribe();
+  }
+
+  goBack() {
+    this.router.navigate(['metrics', 'institution']);
   }
 }


### PR DESCRIPTION
Add the back button to metrics library page.
updated metric card to align with libray.
update detail popup to align with different dashboards. moved "use metrics" from detail to card.

**Story/Ticket Reference ID from JIRA:**
`Add link here`

**Additional Comments:**
`Add here`

**Checklist:**

- [x] Unit test completed?: (Y/N)
- [x] Docs folder up to date?: (Y/N)
- [x] Add if anything missed: (Y/N)

All checklist are okay.

This PR looks great - it's ready to merge! Please review and let's ship it. :)